### PR TITLE
Eliminate external dependency on Ecto.Changeset in Eventful.Transitable

### DIFF
--- a/lib/eventful/transitable.ex
+++ b/lib/eventful/transitable.ex
@@ -4,6 +4,8 @@ defmodule Eventful.Transitable do
     transitions_module = Keyword.fetch!(options, :transitions_module)
 
     quote do
+      import Ecto.Changeset
+
       def state_changeset(%_{} = resource, attrs) do
         resource
         |> cast(attrs, [unquote(field)])

--- a/test/support/model.ex
+++ b/test/support/model.ex
@@ -1,10 +1,11 @@
 defmodule Eventful.Test.Model do
   @moduledoc false
 
-  use Ecto.Schema
-  import Ecto.Changeset
-
   use Eventful.Transitable, transitions_module: __MODULE__.Transitions
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
 
   schema "models" do
     field(:current_state, :string, default: "created")


### PR DESCRIPTION
Before `use Eventful.Transitable, transitions_module: __MODULE__.Transitions` needed to be placed after an `import Ecto.Changeset`. If not, the user would get an error without any indication.

This PR eliminates the external dependency to `Ecto.Changeset` in `Eventful.Transitable`.